### PR TITLE
Add option to hide links to media

### DIFF
--- a/WYSIWYG/CKeditor.body.php
+++ b/WYSIWYG/CKeditor.body.php
@@ -398,6 +398,12 @@ class CKeditor_MediaWiki {
 			'section' => 'editing/fckeditor',
 			'label-message' => 'tog-riched_link_paste_text',
 		);        
+		
+		$preferences['riched_link_to_media'] = array(      // 11.03.15
+			'type' => 'toggle',
+			'section' => 'editing/fckeditor',
+			'label-message' => 'tog-riched_link_to_media',
+		); 
         
         if (defined('SMW_HALO_VERSION')) {
             $preferences['riched_load_semantic_toolbar'] = array(
@@ -420,6 +426,8 @@ class CKeditor_MediaWiki {
 			$user->setOption( 'riched_toggle_remember_state', $wgDefaultUserOptions['riched_toggle_remember_state'] );
 		if( !array_key_exists( 'riched_link_paste_text', $user->mOptions ) && !empty( $wgDefaultUserOptions['riched_link_paste_text'] ) ) //08.09.14 RL
 			$user->setOption( 'riched_link_paste_text', $wgDefaultUserOptions['riched_link_paste_text'] );                                //08.09.14 RL 
+                if( !array_key_exists( 'riched_link_to_media', $user->mOptions ) && !empty( $wgDefaultUserOptions['riched_link_to_media'] ) ) // 11.03.15
+			$user->setOption( 'riched_link_to_media', $wgDefaultUserOptions['riched_link_to_media'] );                               
             
 		// Add the "disable rich editor on namespace X" toggles too
 		foreach( self::$nsToggles as $newToggle ){
@@ -611,6 +619,7 @@ var fck_mv_plg_strtr_span_counter = 0; //16.01.15 RL
 var is_special_elem_with_text_tags = ' . ( isset($wgFCKEditorSpecialElementWithTextTags) && $wgFCKEditorSpecialElementWithTextTags == 1 ? 1 : 0 ) . '; //Syntaxhighlight-Nowiki-Pre
 var smwghQiLoadUrl = "'. CKeditor_MediaWiki::GetQILoadUrl() .'";
 var linkPasteText = ' . ( $wgUser->getOption( 'riched_link_paste_text', $wgDefaultUserOptions['riched_link_paste_text']  ) ?  1 : 0 ) . '; //08.09.14 RL
+var linkToMedia = ' . ( $wgUser->getOption( 'riched_link_to_media', $wgDefaultUserOptions['riched_link_to_media']  ) ?  1 : 0 ) . ';  // 11.03.15
 
 CKEDITOR.ready=true;
 ';

--- a/WYSIWYG/CKeditor.i18n.php
+++ b/WYSIWYG/CKeditor.i18n.php
@@ -37,7 +37,8 @@ $messages['en'] = array(
 	'tog-riched_toggle_remember_state' => 'Remember last toggle state',
     'load-stb-on-startup' => 'Open Semantic Toolbar automatically',
     'tog-riched_link_paste_text' => 'Paste selected text as link text into link -dialog',
-    'tog-riched_wait_page_load' => 'Loading page, please wait...',	
+    'tog-riched_wait_page_load' => 'Loading page, please wait...',
+    'tog-riched_link_to_media' => 'Use links to files [[Media:<link>]]',
 );
 
 /** Message documentation (Message documentation)
@@ -480,6 +481,7 @@ $messages['fr'] = array(
 	'tog-riched_toggle_remember_state' => "Se souvenir de la dernière selection de l'éditeur",
     'tog-riched_link_paste_text' => "Reprendre la sélection comme texte de lien dans la fenêtre de lien",
     'tog-riched_wait_page_load' => 'Chargement de la page, patienter...',
+    'tog-riched_link_to_media' => 'Utiliser les liens vers les fichiers [[Media:<link>]]',
 );
 
 /** Galician (Galego)

--- a/WYSIWYG/CKeditorSajax.body.php
+++ b/WYSIWYG/CKeditorSajax.body.php
@@ -161,9 +161,10 @@ function wfSajaxSearchImageCKeditor( $term ) {
 }
 
 function wfSajaxSearchArticleCKeditor( $term ) {
-	global $wgContLang, $wgExtraNamespaces;
+	global $wgContLang, $wgExtraNamespaces, $wgUser; // 11.03.15 : + $wgUser
 	$limit = 30;
-	$ns = array(NS_MAIN, NS_CATEGORY, NS_IMAGE, NS_TEMPLATE, NS_USER);
+	$ns = array(NS_MAIN, NS_CATEGORY, NS_IMAGE, NS_TEMPLATE, NS_USER); // 11.03.15 : - NS_IMAGE
+	if ($wgUser->getOption( 'riched_link_to_media', $wgDefaultUserOptions['riched_link_to_media']  )) $ns[] = NS_IMAGE;  // 11.03.15
     if (defined('SF_NS_FORM')) $ns[]= SF_NS_FORM;
     if (defined('SMW_NS_PROPERTY')) $ns[]= SMW_NS_PROPERTY;
 

--- a/WYSIWYG/WYSIWYG.php
+++ b/WYSIWYG/WYSIWYG.php
@@ -144,6 +144,7 @@ $wgDefaultUserOptions['riched_start_disabled'] = 0;
 $wgDefaultUserOptions['riched_use_popup'] = 0; // 06.03.15 Varlin 1=>0. Popup is unsupported/untested and will most likely fail with this branch of wysiwyg.
 $wgDefaultUserOptions['riched_toggle_remember_state'] = 1;
 $wgDefaultUserOptions['riched_link_paste_text'] = 1; // 08.09.14 RL
+$wgDefaultUserOptions['riched_link_to_media'] = 1;   // 11.03.15
 
 // when SMWHalo is used then the QueryInterface opens in an Iframe
 // also add setting that the Semantic toobar is loaded by default

--- a/WYSIWYG/ckeditor/plugins/mediawiki/dialogs/link.js
+++ b/WYSIWYG/ckeditor/plugins/mediawiki/dialogs/link.js
@@ -93,6 +93,8 @@ CKEDITOR.dialog.add( 'MWLink', function( editor ) {
             select = dialog.getContentElement( 'mwLinkTab1', 'linkList' );
         target.setValue(select.getValue().replace(/_/g, ' '));
     }
+    
+    if ( linkToMedia ) { var displayLinkAsMedia = ''; } else { var displayLinkAsMedia = 'display: none;' } // 11.03.2015
 
         return {
             title : editor.lang.mwplugin.linkTitle,
@@ -137,6 +139,7 @@ CKEDITOR.dialog.add( 'MWLink', function( editor ) {
                             type : 'checkbox',
                             label : editor.lang.mwplugin.linkAsMedia,
                             title : editor.lang.mwplugin.linkAsMediaTitle,
+                            style : displayLinkAsMedia, // 11.03.15
                             'default' : false
                         },						
                         { //01.03.14 RL


### PR DESCRIPTION
Add a preference option to : 
- hide images/files in the search results of the link dialog
- hide the checkbox "link to media" in the link dialog

This option is set by default to true, so it doesn't make change for normal user, but it makes possible to set : 
$wgDefaultUserOptions['riched_link_to_media'] = false;  
