### PR TITLE
Fix problem with alphabetical sorting

### DIFF
--- a/WYSIWYG/CKeditorSajax.body.php
+++ b/WYSIWYG/CKeditorSajax.body.php
@@ -261,7 +261,7 @@ function wfSajaxSearchCategoryCKeditor(){
 		"AND tmpSelectCatPage.page_namespace =$ns ) ".
 		"LEFT JOIN ".$dbr->tableName('categorylinks')." AS tmpSelectCat2 ON tmpSelectCatPage.page_id = tmpSelectCat2.cl_from ".
 		"WHERE tmpSelectCat2.cl_from IS NULL ".
-		"GROUP BY tmpSelectCat1.cl_to";
+		"GROUP BY tmpSelectCat1.cl_to COLLATE utf8_unicode_ci";
 
 	$res = $dbr->query( $m_sql, __METHOD__ );
 


### PR DESCRIPTION
Alphabetical sorting of categories is not always correct. For example in French, with this function the letter "É" is not like "E", it is put to the end of the list. With this fix, it will correctly be sorted between "D" and "F".